### PR TITLE
Add QR scanning example page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ securityapp/       Python package with the Flask application
   ├── qr_utils.py  – Helper to generate a base64 encoded QR code
 app/
   ├── index.html   – Example page showing a placeholder QR image
+  ├── scan_purchase.html – Demonstrates scanning a QR code and posting a purchase
   └── qr_placeholder.svg – Pre-generated SVG used by the page
 ```
 
@@ -41,6 +42,10 @@ endpoint is called.
 
 Open `app/index.html` in a browser to view a simple page that displays a placeholder QR
 code. The code was generated using `app/generate_placeholder_qr_svg.py`.
+
+`app/scan_purchase.html` demonstrates scanning a QR code with the browser camera
+and sending the decoded user ID along with an item name to the `/purchase`
+endpoint.
 
 ## License
 

--- a/app/scan_purchase.html
+++ b/app/scan_purchase.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8"/>
+<title>QR Purchase Scanner</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 20px; }
+  #reader { width: 300px; margin: 20px auto; }
+</style>
+</head>
+<body>
+<h1>QRコード購入登録</h1>
+<p>QRコードをカメラで読み取ると購入情報を <code>/purchase</code> エンドポイントへ送信します。</p>
+<label>商品名: <input type="text" id="item" value="sample_item"></label>
+<div id="reader"></div>
+<pre id="log"></pre>
+<script src="https://unpkg.com/html5-qrcode" type="text/javascript"></script>
+<script>
+const log = document.getElementById('log');
+function appendLog(msg) { log.textContent += msg + "\n"; }
+
+function onScanSuccess(decodedText) {
+  appendLog(`QR読み取り成功: ${decodedText}`);
+  const item = document.getElementById('item').value;
+  fetch('/purchase', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: decodedText, item })
+  })
+  .then(r => r.json())
+  .then(data => appendLog(JSON.stringify(data)))
+  .catch(err => appendLog('送信エラー: ' + err));
+}
+
+new Html5Qrcode("reader").start({ facingMode: "environment" }, {
+  fps: 10,
+  qrbox: 250
+}, onScanSuccess);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `scan_purchase.html` to show a basic QR code scanner
- document the new page in the README

## Testing
- `python -m securityapp.app` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6844df91b2088330aee2ffeedd700224